### PR TITLE
feat(sentry): remove sentry env support

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,10 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_ENV = process.env.SENTRY_ENV || "unknown";
-
 Sentry.init({
   // TODO(platform): update DSN
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  environment: SENTRY_ENV,
   tracesSampleRate: 1.0,
 });

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -1,10 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_ENV = process.env.SENTRY_ENV || "unknown";
-
 Sentry.init({
   // TODO(platform): update DSN
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-  environment: SENTRY_ENV,
   tracesSampleRate: 1.0,
 });


### PR DESCRIPTION
Since we are going to do trunk based dev on all platforms, we can safely remove the Sentry environment value. Each error reported to Sentry could either happen on a prod or acc environment, but that isn't relevant. Since it may as well happen on prod since the same build is deployed there.