### PR TITLE
chore(vendor): update @lightbase/internal-management

### DIFF
--- a/vendor/internal-management/package.json
+++ b/vendor/internal-management/package.json
@@ -5,19 +5,19 @@
   "main": "./src/index.tsx",
   "dependencies": {
     "@emotion/hash": "^0.9.0",
-    "@emotion/react": "^11.10.4",
-    "@headlessui/react": "^1.7.3",
-    "@tanstack/react-query": "4.10.3",
+    "@emotion/react": "11.10.5",
+    "@headlessui/react": "1.7.4",
+    "@tanstack/react-query": "4.14.5",
     "axios": "0.27.2",
     "jwt-decode": "3.1.2",
     "nookies": "^2.5.2",
-    "react-hook-form": "7.37.0",
-    "react-router-dom": "^6.4.2",
+    "react-hook-form": "7.39.1",
+    "react-router-dom": "6.4.3",
     "twind": "0.16.17"
   },
   "files": [
     "README.md",
     "src"
   ],
-  "gitHead": "049c6603bb60fe63712c55a766a5fcebccde7beb"
+  "gitHead": "c88109f2a740293ef6ca7ce2ee97d12f03378cdc"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,7 +279,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.10.4":
+"@emotion/react@11.10.5":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
@@ -344,10 +344,12 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@headlessui/react@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.3.tgz#853c598ff47b37cdd192c5cbee890d9b610c3ec0"
-  integrity sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==
+"@headlessui/react@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.4.tgz#ba7f50fda20667276ee84fcd4c2a459aa26187e3"
+  integrity sha512-D8n5yGCF3WIkPsjEYeM8knn9jQ70bigGGb5aUvN6y4BGxcT3OcOQOKcM3zRGllRCZCFxCZyQvYJF6ZE7bQUOyQ==
+  dependencies:
+    client-only "^0.0.1"
 
 "@hookform/resolvers@2.9.8":
   version "2.9.8"
@@ -530,10 +532,10 @@
     "@types/node" "*"
     playwright-core "1.27.1"
 
-"@remix-run/router@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.2.tgz#1c17eadb2fa77f80a796ad5ea9bf108e6993ef06"
-  integrity sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ==
+"@remix-run/router@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.3.tgz#953b88c20ea00d0eddaffdc1b115c08474aa295d"
+  integrity sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==
 
 "@rollup/plugin-sucrase@4.0.4":
   version "4.0.4"
@@ -803,12 +805,25 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.10.3.tgz#a6477bab9ed1ae4561ca0a59ae06f8c615c692b7"
   integrity sha512-+ME02sUmBfx3Pjd+0XtEthK8/4rVMD2jcxvnW9DSgFONpKtpjzfRzjY4ykzpDw1QEo2eoPvl7NS8J5mNI199aA==
 
+"@tanstack/query-core@4.14.5":
+  version "4.14.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.14.5.tgz#f8c061a9dd4d7a87f9992db4ddda35c479e93c4a"
+  integrity sha512-Su1AyrPb6xnm7wXTvpN5tt+B7LViYSh9k04vvuc6+eMVH0HkE9ktZTXibRrTvV83BI1KP5MG7v/k90ne/4zQzw==
+
 "@tanstack/react-query@4.10.3":
   version "4.10.3"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.10.3.tgz#294deefa0fb6ada88bc4631d346ef5d5551c5443"
   integrity sha512-4OEJjkcsCTmG3ui7RjsVzsXerWQvInTe95CBKFyOV/GchMUlNztoFnnYmlMhX7hLUqJMhbG9l7M507V7+xU8Hw==
   dependencies:
     "@tanstack/query-core" "4.10.3"
+    use-sync-external-store "^1.2.0"
+
+"@tanstack/react-query@4.14.5":
+  version "4.14.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.14.5.tgz#e2ff6419ee94426ec5e0eecf9bf77efbeb1a0e4b"
+  integrity sha512-CuWl/SxSB0zHhHaTja8LNhy9Vdk+vk9IkW3Oiq3lo4gPnTguHmbUzfjEA1x3RfvPeHfPMuq/pYMSbV+CX4aDQA==
+  dependencies:
+    "@tanstack/query-core" "4.14.5"
     use-sync-external-store "^1.2.0"
 
 "@trysound/sax@0.2.0":
@@ -1364,6 +1379,11 @@ classnames@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -3289,6 +3309,11 @@ react-hook-form@7.37.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.37.0.tgz#4d1738f092d3d8a3ade34ee892d97350b1032b19"
   integrity sha512-6NFTxsnw+EXSpNNvLr5nFMjPdYKRryQcelTHg7zwBB6vAzfPIcZq4AExP4heVlwdzntepQgwiOQW4z7Mr99Lsg==
 
+react-hook-form@7.39.1:
+  version "7.39.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.39.1.tgz#ded87d4b3f6692d1f9219515f78ca282b6e1ebf7"
+  integrity sha512-MiF9PCILN5KulhSGbnjohMiTOrB47GerDTichMNP0y2cPUu1GTRFqbunOxCE9N1499YTLMV/ne4gFzqCp1rxrQ==
+
 react-i18next@^11.18.4:
   version "11.18.4"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.18.4.tgz#b3c35ac4c4657b05d599b036536d7b2c0331e248"
@@ -3302,20 +3327,20 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-router-dom@^6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.2.tgz#115b37d501d6d8ac870683694978c51c43e6c0d2"
-  integrity sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==
+react-router-dom@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.3.tgz#70093b5f65f85f1df9e5d4182eb7ff3a08299275"
+  integrity sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==
   dependencies:
-    "@remix-run/router" "1.0.2"
-    react-router "6.4.2"
+    "@remix-run/router" "1.0.3"
+    react-router "6.4.3"
 
-react-router@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.4.2.tgz#300628ee9ed81b8ef1597b5cb98b474efe9779b8"
-  integrity sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==
+react-router@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.4.3.tgz#9ed3ee4d6e95889e9b075a5d63e29acc7def0d49"
+  integrity sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==
   dependencies:
-    "@remix-run/router" "1.0.2"
+    "@remix-run/router" "1.0.3"
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION

_This PR is created by sync and will be force-pushed daily. Overwriting any manual changes done to this PR._

<details> 
<summary>Click to expand the changelog</summary>

- chore(deps): update dependencies (lightbasenl/frontend-components#6)

    _This PR is created by sync and will be force-pushed daily. Overwriting 
    any manual changes done to this PR._
    
    - Bumped @compas/cli (dev) from 0.0.216 to 0.0.218
     - Changelog: https://github.com/compasjs/compas/blob/-/changelog.md
    - Bumped @compas/code-gen (dev) from 0.0.216 to 0.0.218
     - Changelog: https://github.com/compasjs/compas/blob/-/changelog.md
    - Bumped @compas/stdlib (dev) from 0.0.216 to 0.0.218
     - Changelog: https://github.com/compasjs/compas/blob/-/changelog.md
    - Bumped @emotion/react from 11.10.4 to 11.10.5
     - Changelog: https://github.com/emotion-js/emotion/tree/main#readme
    - Bumped @headlessui/react from 1.7.3 to 1.7.4
    - Changelog: 
    https://github.com/tailwindlabs/headlessui/blob/-/packages/@headlessui-react/CHANGELOG.md
    
    - Bumped @tanstack/react-query from 4.10.3 to 4.14.5
     - Changelog: https://github.com/tanstack/query/releases
    - Bumped @types/jest (dev) from 29.1.2 to 29.2.2
    - Bumped @types/node (dev) from 18.8.5 to 18.11.9
    - Bumped @types/react (dev) from 18.0.21 to 18.0.25
    - Bumped @types/react-dom (dev) from 18.0.6 to 18.0.8
    - Bumped @typescript-eslint/eslint-plugin from 5.40.0 to 5.42.0
    - Changelog: 
    https://github.com/typescript-eslint/typescript-eslint/blob/-/packages/eslint-plugin/CHANGELOG.md
    
    - Bumped @typescript-eslint/parser from 5.40.0 to 5.42.0
    - Changelog: 
    https://github.com/typescript-eslint/typescript-eslint/blob/-/packages/parser/CHANGELOG.md
    
    - Bumped eslint from 8.25.0 to 8.27.0
     - Changelog: https://github.com/eslint/eslint/blob/-/CHANGELOG.md
    - Bumped eslint-config-next from 12.3.1 to 13.0.2
     - Changelog: https://github.com/vercel/next.js/releases
    - Bumped jest (dev) from 29.1.2 to 29.2.2
     - Changelog: https://github.com/facebook/jest/blob/-/CHANGELOG.md
    - Bumped next (dev) from 12.3.1 to 13.0.2
     - Changelog: https://github.com/vercel/next.js/releases
    - Bumped react-hook-form from 7.37.0 to 7.39.1
    - Changelog: 
    https://github.com/react-hook-form/react-hook-form/blob/-/CHANGELOG.md
    - Bumped react-router-dom from 6.4.2 to 6.4.3
    - Changelog: 
    https://github.com/remix-run/react-router/blob/-/packages/react-router-dom/CHANGELOG.md
    
     Co-authored-by: github-actions
    <41898282+github-actions[bot]@users.noreply.github.com>
</details>
